### PR TITLE
Some simplifications

### DIFF
--- a/src/main/java/org/resthub/todo/TodoInitializer.java
+++ b/src/main/java/org/resthub/todo/TodoInitializer.java
@@ -3,7 +3,6 @@ package org.resthub.todo;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRegistration;
 import org.springframework.web.WebApplicationInitializer;
-import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
 
@@ -11,13 +10,6 @@ public class TodoInitializer implements WebApplicationInitializer {
 
     @Override
     public void onStartup(ServletContext servletContext) {
-
-        // Create the 'root' Spring application context
-        AnnotationConfigWebApplicationContext rootContext = new AnnotationConfigWebApplicationContext();
-        rootContext.register(WebConfig.class);
-
-        // Manage the lifecycle of the root application context
-        servletContext.addListener(new ContextLoaderListener(rootContext));
 
         // Create the dispatcher servlet's Spring application context
         AnnotationConfigWebApplicationContext dispatcherContext = new AnnotationConfigWebApplicationContext();

--- a/src/main/java/org/resthub/todo/WebConfig.java
+++ b/src/main/java/org/resthub/todo/WebConfig.java
@@ -2,7 +2,6 @@ package org.resthub.todo;
 
 import com.mongodb.Mongo;
 import java.net.UnknownHostException;
-import javax.inject.Inject;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -13,9 +12,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration @EnableWebMvc @ComponentScan(basePackages = "org.resthub.todo")
 public class WebConfig extends WebMvcConfigurerAdapter {
-    
-    @Inject
-    private Mongo mongo;
     
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -31,8 +27,8 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     }
     
     @Bean
-    public MongoTemplate mongoTemplate() {
-        return new MongoTemplate(mongo, "todo");
+    public MongoTemplate mongoTemplate() throws UnknownHostException {
+        return new MongoTemplate(mongo(), "todo");
     }
        
 }


### PR DESCRIPTION
Hi,

nice example! I had a look, and you're configuring a root context with the same beans as the DispatcherServlet context. That's pointless, so you can simply remove that code. Also, there's no need to inject the result of an @Bean method in a field in the same class: you can simply invoke the method. That still preserves proper singleton behavior, because Spring will create a CGLib proxy that overrides every @Bean method (for exactly this purpose). I took the liberty of making these changes for you, so if you accept this pull request then you'll have these changes immediately. 
